### PR TITLE
feat(DEV-2673): hide yin yang guide for iOS

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,70 +30,79 @@ class _MyAppState extends State<MyApp> {
           appBar: AppBar(
             title: const Text('Plugin example app'),
           ),
-          body: Column(
-            children: [
-              Text(
-                helperText,
-                style: const TextStyle(color: Colors.black),
-              ),
-              Expanded(
-                child: PanoramicCameraWidget(
-                  showGuide: true,
-                  onCameraStarted: () {
-                    debugPrint("---------------onCameraStarted---------------");
-                    setState(() {
-                      helperText = 'Tap to start';
-                      photos = 0;
-                    });
-                  },
-                  onCameraStopped: () {
-                    debugPrint("---------------onCameraStopped---------------");
-                  },
-                  onCanceledPreparingToShoot: () {
-                    debugPrint("---------------onCameraStopped---------------");
-                  },
-                  onTakingPhoto: () {
-                    setState(() {
-                      helperText = 'Tacking photo';
-                    });
-                  },
-                  onPhotoTaken: () {
-                    debugPrint("---------------onPhotoTaken---------------");
-                    photos++;
-                    if (photos <= 0) {
+          body: SizedBox(
+            width: double.infinity,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  helperText,
+                  style: const TextStyle(color: Colors.black),
+                ),
+                SizedBox(
+                  height: 630,
+                  width: 330,
+                  child: PanoramicCameraWidget(
+                    showGuide: true,
+                    onCameraStarted: () {
+                      debugPrint(
+                          "---------------onCameraStarted---------------");
                       setState(() {
                         helperText = 'Tap to start';
+                        photos = 0;
                       });
-                    } else if (photos == 1) {
+                    },
+                    onCameraStopped: () {
+                      debugPrint(
+                          "---------------onCameraStopped---------------");
+                    },
+                    onCanceledPreparingToShoot: () {
+                      debugPrint(
+                          "---------------onCameraStopped---------------");
+                    },
+                    onTakingPhoto: () {
                       setState(() {
-                        helperText = 'Rotate left or right or tap to restart';
+                        helperText = 'Tacking photo';
                       });
-                    } else {
-                      setState(() {
-                        helperText =
-                            'Tap to finish when ready or continue rotating';
-                      });
-                    }
-                  },
-                  onDeviceVerticalityChanged: (int val) {
-                    isVertical = val;
-                    if (isVertical == 1) {
-                      if (!isShootingStarted) {
+                    },
+                    onPhotoTaken: () {
+                      debugPrint("---------------onPhotoTaken---------------");
+                      photos++;
+                      if (photos <= 0) {
                         setState(() {
                           helperText = 'Tap to start';
                         });
+                      } else if (photos == 1) {
+                        setState(() {
+                          helperText = 'Rotate left or right or tap to restart';
+                        });
+                      } else {
+                        setState(() {
+                          helperText =
+                              'Tap to finish when ready or continue rotating';
+                        });
                       }
-                    } else {
-                      setState(() {
-                        helperText = 'Hold the device vertically';
-                      });
-                    }
-                    debugPrint(
-                        "---------------onDeviceVerticalityChanged: $val---------------");
-                  },
+                    },
+                    onDeviceVerticalityChanged: (int val) {
+                      isVertical = val;
+                      if (isVertical == 1) {
+                        if (!isShootingStarted) {
+                          setState(() {
+                            helperText = 'Tap to start';
+                          });
+                        }
+                      } else {
+                        setState(() {
+                          helperText = 'Hold the device vertically';
+                        });
+                      }
+                      debugPrint(
+                          "---------------onDeviceVerticalityChanged: $val---------------");
+                    },
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           )),
     );
   }

--- a/ios/Classes/PanoramicCameraPlugin.m
+++ b/ios/Classes/PanoramicCameraPlugin.m
@@ -5,8 +5,6 @@
 
 @implementation PanoramicCameraPlugin {
     FlutterMethodChannel *_channel;
-    UIWindow *_window;
-    ShooterViewController *_shooterViewController;
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/Classes/PanoramicCameraView.m
+++ b/ios/Classes/PanoramicCameraView.m
@@ -18,15 +18,11 @@
         _channel = channel;
 
         // Initialize and add ShooterViewController with the method channel
-        _shooterViewController = [[ShooterViewController alloc] initWithMethodChannel:_channel];
+        _shooterViewController = [[ShooterViewController alloc] initWithMethodChannel:_channel frame:frame];
         _shooterViewController.view.frame = _view.bounds;
         _shooterViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         [_view addSubview:_shooterViewController.view];
 
-        // Ensure the ShooterViewController is properly added to the view hierarchy
-        UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        [rootViewController addChildViewController:_shooterViewController];
-        [_shooterViewController didMoveToParentViewController:rootViewController];
     }
     return self;
 }

--- a/ios/Classes/PanoramicCameraViewFactory.m
+++ b/ios/Classes/PanoramicCameraViewFactory.m
@@ -16,9 +16,17 @@
     return self;
 }
 
+- (NSObject<FlutterMessageCodec>*)createArgsCodec {
+    return [FlutterStandardMessageCodec sharedInstance];
+}
+
 - (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
                                             viewIdentifier:(int64_t)viewId
                                                  arguments:(id _Nullable)args {
+        // This allows the camera view to be displayed in all the available space of the widget.
+        NSNumber *height = args[@"height"];
+        NSNumber *width = args[@"width"];
+        frame = CGRectMake(0, 0, [width floatValue], [height floatValue]);
     PanoramicCameraView* cameraView = [[PanoramicCameraView alloc] initWithFrame:frame
                                                                  viewIdentifier:viewId
                                                                       arguments:args

--- a/ios/Classes/ShooterViewController.h
+++ b/ios/Classes/ShooterViewController.h
@@ -19,7 +19,7 @@
 - (void)restart:(id)sender;
 - (void)stop:(id)sender;
 - (void)leaveShooter;
-- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel;
+- (instancetype)initWithMethodChannel:(FlutterMethodChannel *)channel frame:(CGRect)frame;
 
 @end
 

--- a/lib/panoramic_camera.dart
+++ b/lib/panoramic_camera.dart
@@ -153,11 +153,21 @@ class _PanoramicCameraWidgetState extends State<PanoramicCameraWidget>
   @override
   Widget build(BuildContext context) {
     if (defaultTargetPlatform == TargetPlatform.iOS) {
-      return const UiKitView(
-        viewType: 'panoramic_view',
-        layoutDirection: TextDirection.ltr,
-        creationParams: null,
-        creationParamsCodec: StandardMessageCodec(),
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final height = constraints.maxHeight;
+          final width = constraints.maxWidth;
+
+          return SizedBox(
+            height: height,
+            width: width,
+            child: UiKitView(
+              viewType: 'panoramic_view',
+              creationParams: {'height': height, 'width': width},
+              creationParamsCodec: const StandardMessageCodec(),
+            ),
+          );
+        },
       );
     }
     return const AndroidView(viewType: 'panoramic_view');


### PR DESCRIPTION
We cannot functionally hide the yin yang because an exception appears indicating that a higher plan is needed, so the provisional solution I provided is to crop the portion of the view containing the guide.

I also updated the plugin so that the camera respects the space that the widget has

Result:

https://github.com/Genopets/panoramic-camera-widget/assets/44868985/44649c7c-2899-47d2-ba7a-16f4f1ce3fde

Panoramic photo: 

![IMG_0087](https://github.com/Genopets/panoramic-camera-widget/assets/44868985/dadb3433-8d7a-4633-b8d1-931f2e414627)


Other things I've already tried and they don't work:

- I have tried initializing another camera and not adding the sv view to my application while taking advantage of the sensors it manages, but the library restricts opening any other camera.
- Edit the SV subviews to become transparent so that will hide the guide.

Since we cannot know the content of libDMD_LITE.a, it is difficult to find a way to modify the logic it contains.



