### PR TITLE
fix(DEV-2927): add panoramic view safely

### DIFF
--- a/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
+++ b/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
@@ -61,9 +61,6 @@ class CustomView @JvmOverloads constructor(
         }
 
         override fun onFinishRelease() {
-            mRelativeLayout.removeView(viewGroup);
-            viewGroup = null;
-            mDMDCapture.startCamera(activity, logoSize, logoSize)
             mainHandler.post { channel.invokeMethod("onFinishRelease", null) }
         }
 
@@ -124,7 +121,6 @@ class CustomView @JvmOverloads constructor(
 
         override fun onFinishGeneratingEqui() {
             mIsShootingStarted = false
-            mDMDCapture.startCamera(activity, logoSize, logoSize)
             mainHandler.post { channel.invokeMethod  ("onFinishGeneratingEqui", mEquiPath) }
         }
 
@@ -205,8 +201,18 @@ class CustomView @JvmOverloads constructor(
     }
 
     fun onResume() {
-        mRelativeLayout.addView(viewGroup);
-        mDMDCapture.startCamera(activity, logoSize, logoSize)
+        try {
+            // Ensure viewGroup is not already attached to another parent
+            val currentParent = viewGroup?.parent as? ViewGroup
+            currentParent?.removeView(viewGroup)
+
+            // Add viewGroup to mRelativeLayout
+            mRelativeLayout.addView(viewGroup)
+            mDMDCapture.startCamera(activity, logoSize, logoSize)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error starting camera: ${e.message}", e)
+            throw Exception("Error starting camera: ${e.message}", e)
+        }
     }
 
     fun startShooting() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -102,26 +102,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -150,17 +150,17 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   panoramic_camera:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.0.2"
   path:
     dependency: transitive
     description:
@@ -250,10 +250,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -266,10 +266,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   webdriver:
     dependency: transitive
     description:
@@ -280,4 +280,4 @@ packages:
     version: "3.0.3"
 sdks:
   dart: ">=3.3.4 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
-description: "A new Flutter plugin project."
-version: 0.0.1
+description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
+version: 0.0.2
 homepage:
 
 environment:


### PR DESCRIPTION
- I solved the error related to the view, which occurred when the view was added again and for some reason the previous one was not removed properly, the solution was to make this safer, first check if it was not previously added and remove it.
- I'm wrapping the start of the camera in a try catch, this to track errors.