### PR TITLE
fix(DEV-2926): add custom loader for camera

### DIFF
--- a/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
+++ b/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
@@ -43,6 +43,7 @@ class CustomView @JvmOverloads constructor(
 
     private var logoSize = 500
     private var outputHeight: Int = 500
+    private var showLogo = true
 
 
     private val mCallbackInterface: CallbackInterfaceShooter = object : CallbackInterfaceShooter {
@@ -65,7 +66,7 @@ class CustomView @JvmOverloads constructor(
         }
 
         override fun onDirectionUpdated(direction: Float) {
-            mainHandler.post { channel.invokeMethod("onDirectionUpdated", direction) }
+//            mainHandler.post { channel.invokeMethod("onDirectionUpdated", direction) }
         }
 
         override fun preparingToShoot() {
@@ -208,10 +209,29 @@ class CustomView @JvmOverloads constructor(
 
             // Add viewGroup to mRelativeLayout
             mRelativeLayout.addView(viewGroup)
+
+            if (!showLogo){
+                removeViewByClass(this, "YinYangGLView")
+            }
+
             mDMDCapture.startCamera(activity, logoSize, logoSize)
         } catch (e: Exception) {
             Log.e(TAG, "Error starting camera: ${e.message}", e)
             throw Exception("Error starting camera: ${e.message}", e)
+        }
+    }
+
+    private fun removeViewByClass(viewGroup: ViewGroup, className: String) {
+        for (i in 0 until viewGroup.childCount) {
+            val child = viewGroup.getChildAt(i)
+            if (child.javaClass.simpleName == className) {
+                viewGroup.removeViewAt(i)
+                Log.d("ViewPrinter", "Removed view of class: $className at index $i")
+                return
+            }
+            if (child is ViewGroup) {
+                removeViewByClass(child, className)
+            }
         }
     }
 
@@ -244,6 +264,7 @@ class CustomView @JvmOverloads constructor(
 
     fun setShowLogo(showLogo: Boolean) {
         if(!showLogo) logoSize = 10
+        this.showLogo = showLogo;
     }
 
     // All this logic is necessary to send percentage updates to the channel
@@ -257,7 +278,7 @@ class CustomView @JvmOverloads constructor(
                 var map = mDMDCapture.getIndicators()
                 mainHandler.post { channel.invokeMethod  ("onUpdateIndicators", map) }
 
-                timerHandler?.postDelayed(this, 100)
+                timerHandler?.postDelayed(this, 500)
             }
         }
         timerHandler?.post(timerRunnable!!)

--- a/ios/Classes/ShooterViewController.mm
+++ b/ios/Classes/ShooterViewController.mm
@@ -72,8 +72,17 @@ UIImageView *btnHDR = nil;
 - (void)setupMethodChannel {
     __weak typeof(self) weakSelf = self;
     [_channel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
-        if ([@"startShooting" isEqualToString:call.method]) {
+        NSString *method = call.method;
+        if ([method isEqualToString:@"startShooting"]) {
             [weakSelf startShooting];
+            result(nil);
+        } else if ([method isEqualToString:@"onResume"]) {
+            result(nil);
+        } else if ([method isEqualToString:@"onPause"]) {
+            result(nil);
+        } else if ([method isEqualToString:@"setShowGuide"]) {
+            result(nil);
+        } else if ([method isEqualToString:@"setOutputHeight"]) {
             result(nil);
         } else {
             result(FlutterMethodNotImplemented);

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,25 @@
+class PanoramicMethodNames {
+  static const String onCameraStopped = 'onCameraStopped';
+  static const String onCameraStarted = 'onCameraStarted';
+  static const String onFinishClear = 'onFinishClear';
+  static const String onFinishRelease = 'onFinishRelease';
+  static const String preparingToShoot = 'preparingToShoot';
+  static const String canceledPreparingToShoot = 'canceledPreparingToShoot';
+  static const String takingPhoto = 'takingPhoto';
+  static const String photoTaken = 'photoTaken';
+  static const String shootingCompleted = 'shootingCompleted';
+  static const String onDirectionUpdated = 'onDirectionUpdated';
+  static const String deviceVerticalityChanged = 'deviceVerticalityChanged';
+  static const String compassEvent = 'compassEvent';
+  static const String onFinishGeneratingEqui = 'onFinishGeneratingEqui';
+  static const String onExposureChanged = 'onExposureChanged';
+  static const String onRotatorConnected = 'onRotatorConnected';
+  static const String onRotatorDisconnected = 'onRotatorDisconnected';
+  static const String onStartedRotating = 'onStartedRotating';
+  static const String onFinishedRotating = 'onFinishedRotating';
+  static const String onUpdateIndicators = 'onUpdateIndicators';
+  static const String onResume = 'onResume';
+  static const String onPause = 'onPause';
+  static const String startShooting = 'startShooting';
+  static const String finishShooting = 'finishShooting';
+}

--- a/lib/panoramic_camera_controller.dart
+++ b/lib/panoramic_camera_controller.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:panoramic_camera/constants.dart';
 import 'package:panoramic_camera/panoramic_camera_interface.dart';
 
 class PanoramicCameraController {
@@ -37,19 +36,19 @@ class PanoramicCameraController {
   }
 
   Future<void> onResume() async {
-    if (Platform.isAndroid) return _cameraControl?.invokeMethod('onResume');
+    return _cameraControl?.invokeMethod(PanoramicMethodNames.onResume);
   }
 
   Future<void> onPause() async {
-    if (Platform.isAndroid) return _cameraControl?.invokeMethod('onPause');
+    return _cameraControl?.invokeMethod(PanoramicMethodNames.onPause);
   }
 
   Future<void> startShooting() async {
-    await _cameraControl?.invokeMethod('startShooting');
+    await _cameraControl?.invokeMethod(PanoramicMethodNames.startShooting);
   }
 
   Future<void> finishShooting() async {
-    await _cameraControl?.invokeMethod('finishShooting');
+    await _cameraControl?.invokeMethod(PanoramicMethodNames.finishShooting);
   }
 
   VoidCallback? onCameraStopped;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
 description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
-version: 0.0.2
+version: 0.0.3
 homepage:
 
 environment:


### PR DESCRIPTION
## Description

- To remove the yin yang loader I am searching and removing that view from the main activity.
- For practical reasons I created an additional attribute that receives a widget which will be used as a loader.
- I changed the names of the method channels to constants as a good practice

With these changes we can put a custom loader in genopets app as seen in this video:

https://github.com/Genopets/panoramic-camera-widget/assets/44868985/807d616c-6896-49ab-b7e8-aa57dbbde9fc

