### PR TITLE
fix(DEV-3194): remove yin yang using index-based removal

### DIFF
--- a/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
+++ b/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
@@ -210,11 +210,18 @@ class CustomView @JvmOverloads constructor(
             mRelativeLayout.addView(viewGroup);
 
             if (!showLogo){
-                removeViewByClass(this, "YinYangGLView")
+                removeViewByIndex(viewGroup!!, 3)
             }
             mDMDCapture.startCamera(activity, logoSize, logoSize)
         } catch (e: Exception) {
             Log.e(TAG, "Error starting camera: ${e.message}")
+        }
+    }
+
+    private fun removeViewByIndex(viewGroup: ViewGroup, index: Int) {
+        if (index >= 0 && index < viewGroup.childCount) {
+            val child = viewGroup.getChildAt(index)
+            viewGroup.removeViewAt(index)
         }
     }
 
@@ -225,9 +232,6 @@ class CustomView @JvmOverloads constructor(
                 viewGroup.removeViewAt(i)
                 Log.d("ViewPrinter", "Removed view of class: $className at index $i")
                 return
-            }
-            if (child is ViewGroup) {
-                removeViewByClass(child, className)
             }
         }
     }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.5"
+    version: "0.0.6"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
 description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
-version: 0.0.5
+version: 0.0.6
 homepage:
 
 environment:


### PR DESCRIPTION
### Description

In development env, the `removeViewByClass` method worked correctly to hide the Yin Yang view. However, in staging builds, due to code obfuscation, the class name can change, preventing this method from finding and removing the view properly.

Changes Made:

- Added a `removeViewByIndex` method that removes the view based on a fixed index instead of the class name.
- Adjusted the logic to use `removeViewByIndex` instead of `removeViewByClass` when hiding the Yin Yang view.

These changes ensure that the Yin Yang view is removed correctly in development, staging and production envs, eliminating the dependency on class names that may change due to obfuscation.