### PR TITLE
feat(DEV-3494): update example project to support to simulate releases

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "panoramic_camera",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "panoramic_camera (profile mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "panoramic_camera (release mode)",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart"
+        },
+        {
+            "name": "example (profile mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "profile"
+        },
+        {
+            "name": "example (release mode)",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        }
+    ]
+}

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -52,6 +52,9 @@ android {
 
     buildTypes {
         release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.nativesystem.** { *; }
+-keepclassmembers class com.nativesystem.** { *; }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,7 +41,9 @@ class _MyAppState extends State<MyApp> {
       onShootingCanceled: (bool value) {
         debugPrint('onShootingCanceled $value');
       },
-      onCameraStopped: () {},
+      onCameraStopped: () {
+        debugPrint('onCameraStopped');
+      },
       onDeviceVerticalityChanged: (int val) {
         isVertical = val;
         if (isVertical == 1) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.8"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
 description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
-version: 0.0.7
+version: 0.0.8
 homepage:
 
 environment:


### PR DESCRIPTION
To ensure that each version does not break the staging environment (stg), I updated the example project and created build profiles to simulate the same behavior as the production builds.

It is no longer necessary to edit the SDK to support flavors, as the issue related to flavors was resolved by the SDK provider. After multiple tests, it was noticed that the problems during the build process were related to code obfuscation. Therefore, it is important to avoid obfuscating the SDK.