### PR TITLE
fix(DEV-3509): normalize the behavior of the startShooting method

### DIFF
--- a/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
+++ b/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
@@ -239,6 +239,9 @@ class CustomView @JvmOverloads constructor(
     }
 
     fun startShooting() {
+        if(mIsShootingStarted){
+            Log.w(TAG, "The camera is already initialized")
+        }
         startTimer()
         val cacheDir = context.externalCacheDir
         mPanoramaPath = cacheDir?.absolutePath + "/Lib_Test/"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.8"
+    version: "0.0.9"
   path:
     dependency: transitive
     description:

--- a/ios/Classes/ShooterViewController.mm
+++ b/ios/Classes/ShooterViewController.mm
@@ -266,13 +266,11 @@ UILabel *label = nil;
 
 - (void)startShooting
 {
-    self.started=!self.started;
-    if(self.started)
-        [self start:nil];
-    else if(!tookPhoto)
-        [self restart:nil];
-    else
-        [self stop:nil];
+    if (self.started) {
+        NSLog(@"Panoramic Camera Plugin: Warning - The camera is already initialized");
+        return;
+    }
+    [self start:nil];
 }
 
 - (void)openLensSelector:(id)sender
@@ -448,6 +446,7 @@ UILabel *label = nil;
                     [self restart:nil];
                     
                     if (success) {
+                        [self stopPrintTimer];
                         [self->_channel invokeMethod:@"onFinishGeneratingEqui" arguments:equiPath];
                     } else if (error) {
                         NSLog(@"Error saving photo: %@", error);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
 description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
-version: 0.0.8
+version: 0.0.9
 homepage:
 
 environment:


### PR DESCRIPTION
### Description

The `startShooting` method initializes the capture of the panoramic photo
The behavior of the method has been normalized now in both Android and iOS If the function is called again and the process has already been initialized previously, this call is ignored and a log is printed.