### PR TITLE
feat(DEV-3769): fix panoramic camera resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.0.13
 
 * Add versioning to repository
+
+## 0.0.14
+
+* Fix full screen bug which caused the camera not to be displayed in full screen

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this library, since it is not published on pub.dev, you should reference 
 panoramic_camera:
   git:
     url: https://github.com/Genopets/panoramic-camera-widget
-    ref: v0.0.13
+    ref: v0.0.14
 ```
 
 ### Installation on iOS

--- a/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
+++ b/android/src/main/kotlin/me/genopets/plugins/panoramic_camera/CustomView.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.os.Build
 import android.os.Environment
 import android.os.Handler
@@ -14,6 +15,7 @@ import android.util.Log
 import android.view.*
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
+import android.widget.LinearLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import com.dermandar.dmd_lib.CallbackInterfaceShooter
@@ -184,6 +186,28 @@ class CustomView @JvmOverloads constructor(
             val displayRotation = getDisplayRotation(activity)
 
             viewGroup = mDMDCapture.initShooter(activity, mCallbackInterface, displayRotation, false, false)
+
+            viewGroup?.let { vg ->
+                // Get the first child of viewGroup, which is the FrameLayout containing CameraPreview2
+                val frameLayout = vg.getChildAt(0) as? FrameLayout
+            
+                // Ensure that frameLayout is not null before proceeding
+                frameLayout?.let {
+                    // Get the first child inside the FrameLayout, which is CameraPreview2
+                    val cameraPreview2 = it.getChildAt(0)
+            
+                    // Ensure that cameraPreview2 is not null before proceeding
+                    cameraPreview2?.let { view ->
+                        // Set the LayoutParams of CameraPreview2 to occupy the entire available space within FrameLayout
+                        val layoutParams = FrameLayout.LayoutParams(
+                            FrameLayout.LayoutParams.MATCH_PARENT,
+                            FrameLayout.LayoutParams.MATCH_PARENT
+                        )
+                        view.layoutParams = layoutParams
+                    }
+                }
+            }
+            
 
         } catch (e: java.lang.Exception){
             Log.e(TAG, e.printStackTrace().toString())

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,9 +127,9 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Plugin example app'),
-      ),
+      // appBar: AppBar(
+      //   title: const Text('Plugin example app'),
+      // ),
       floatingActionButton: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
@@ -157,15 +157,16 @@ class _MyAppState extends State<MyApp> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                Text(
-                  helperText,
-                  style: const TextStyle(color: Colors.black),
-                ),
-                Container(
+                // Text(
+                //   helperText,
+                //   style: const TextStyle(color: Colors.black),
+                // ),
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 300),
                   decoration: BoxDecoration(
-                      border: Border.all(width: 2, color: Colors.yellow)),
-                  height: isHide ? 200 : 630,
-                  width: isHide ? 150 : 330,
+                      border: Border.all(width: 1, color: Colors.yellow)),
+                  width: double.infinity,
+                  height: isHide ? 100 : 808,
                   child: PanoramicCameraWidget(
                     showGuide: true,
                     controller: controller,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -160,7 +160,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.13"
+    version: "0.0.14"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: panoramic_camera
 description: "Flutter widget that integrates with native Android/iOS panoramic camera functionality"
-version: 0.0.13
+version: 0.0.14
 homepage:
 
 environment:


### PR DESCRIPTION
### Description

There was a defect in the library that caused the camera to not cover the entire screen, I looked for the camera layer and forced it to cover as much as possible so that it covered the entire screen.

Before:
![Screenshot_20240902_222704](https://github.com/user-attachments/assets/62f5e6d1-9e3c-41bc-8cc9-3ba7efd15446)

After:
![Screenshot_20240902_222753](https://github.com/user-attachments/assets/3316f4e9-ced9-46c1-a8be-30cac575befb)
